### PR TITLE
ci: bump `actions/checkout` GitHub action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Run tests
       run: |
         npm ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependabot-autoapprove.yml
+++ b/.github/workflows/dependabot-autoapprove.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Approve PR if not already approved
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: Init a git repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Checkout PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/examples/deploy-lambda-container-example.yml
+++ b/examples/deploy-lambda-container-example.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/examples/deploy-lambda-example.yml
+++ b/examples/deploy-lambda-example.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary

Bump [actions/checkout](https://github.com/actions/checkout) to [v5](https://github.com/actions/checkout/releases/tag/v5.0.0) across CI workflows and documentation

CI:
- Upgrade actions/checkout to v5 in all GitHub Actions workflows

Documentation:
- Update README example to use actions/checkout@v5

---

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.