### PR TITLE
feat: support creating and updating container image functions

### DIFF
--- a/__tests__/container_image_support.test.js
+++ b/__tests__/container_image_support.test.js
@@ -1,0 +1,105 @@
+const core = require('@actions/core');
+const originalValidations = require('../validations');
+
+jest.mock('@actions/core');
+
+describe('Container Image Support Tests', () => {
+  let originalEnv;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalEnv = process.env;
+    process.env = { ...originalEnv };
+    process.env.GITHUB_SHA = 'abc123';
+    
+    // Default mock implementations
+    core.getInput.mockImplementation((name) => {
+      const inputs = {
+        'function-name': 'test-function',
+        'package-type': 'Image',
+        'image-uri': '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest',
+        'region': 'us-east-1'
+      };
+      return inputs[name] || '';
+    });
+    
+    core.getBooleanInput.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Package Type Validation', () => {
+    test('should accept Image package type with image-uri', () => {
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(true);
+      expect(result.packageType).toBe('Image');
+      expect(result.imageUri).toBe('123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest');
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
+
+    test('should fail when Image package type is used without image-uri', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'package-type': 'Image',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+      
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(false);
+      expect(core.setFailed).toHaveBeenCalledWith('image-uri must be provided when package-type is "Image"');
+    });
+
+
+    test('should fail when Zip package type is used without code-artifacts-dir', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'package-type': 'Zip',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+      
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(false);
+      expect(core.setFailed).toHaveBeenCalledWith('code-artifacts-dir must be provided when package-type is "Zip"');
+    });
+
+    test('should reject invalid package type', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'package-type': 'InvalidType',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+      
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(false);
+      expect(core.setFailed).toHaveBeenCalledWith('Package type must be either \'Zip\' or \'Image\', got: InvalidType');
+    });
+
+    test('should default to Zip package type when not specified', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'code-artifacts-dir': './artifacts',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+      
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(true);
+      expect(result.packageType).toBe('Zip');
+    });
+  });
+
+
+});

--- a/action.yml
+++ b/action.yml
@@ -4,16 +4,23 @@ inputs:
   function-name:
     description: 'Name of the Lambda function.'
     required: true
+  package-type:
+    description: 'The package type of the Lambda function. Set to "Image" for container image functions, defaults to "Zip" for .zip file functions.'
+    required: false
+    default: 'Zip'
+  image-uri:
+    description: 'The URI of the container image in Amazon ECR. Required when package-type is "Image".'
+    required: false
   code-artifacts-dir:
-    description: 'The path to a directory of code artifacts to zip and deploy to Lambda.'
-    required: true
+    description: 'The path to a directory of code artifacts to zip and deploy to Lambda. Required when package-type is "Zip".'
+    required: false
   handler:
-    description: 'The name of the method within your code that Lambda calls to run your function. Required for .zip file'
-    required: true
+    description: 'The name of the method within your code that Lambda calls to run your function. Required when package-type is "Zip".'
+    required: false
     default: 'index.handler'
   runtime:
-    description: 'The identifier of the runtime. Required for .zip file'
-    required: true
+    description: 'The identifier of the runtime. Required when package-type is "Zip".'
+    required: false
     default: 'nodejs20.x'
   s3-bucket:
     description: 'S3 bucket name to use for Lambda deployment package. If provided, S3 deployment method will be used instead of direct upload.'
@@ -28,7 +35,7 @@ inputs:
     description: 'Set true to validate the request parameters and access permissions without modifying the function code. Applicable for updating function code only. Creating and updating function configuration will be skipped since they do not support dry run.'
     required: false
     default: 'false'
-  revision-id: 
+  revision-id:
     description: 'Update the function only if the revision ID matches the ID that is specified.'
     required: false
   architectures:
@@ -76,7 +83,7 @@ inputs:
   ephemeral-storage:
     description: 'The size of the functions /tmp directory in MB. The default value is 512, but can be any whole number between 512 and 10,240 MB.'
     required: false
-  snap-start: 
+  snap-start:
     description: 'The functions SnapStart setting.'
     required: false
   logging-config:

--- a/examples/deploy-lambda-container-example.yml
+++ b/examples/deploy-lambda-container-example.yml
@@ -1,0 +1,101 @@
+# This workflow deploys a container image to an AWS Lambda function using the Lambda GitHub Action.
+# It uses OpenID Connect (OIDC) to authenticate with AWS instead of long-term access keys.
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Configure AWS IAM OIDC identity provider for GitHub Actions:
+#    - Go to the IAM console, navigate to "Identity providers", and create a new provider
+#    - Use https://token.actions.githubusercontent.com as the provider URL
+#    - Use sts.amazonaws.com as the audience
+#    - Complete the wizard to create the provider
+#
+# 2. Create an IAM role for GitHub Actions:
+#    - Create a new role with Web Identity as the trusted entity
+#    - Select the OIDC provider you created above
+#    - For "Audience", enter "sts.amazonaws.com"
+#    - Add a condition to limit the role to your repository:
+#      token.actions.githubusercontent.com:sub: repo:your-org/your-repo:*
+#    - Attach policies for Lambda and ECR permissions (Can be found on the README.md)
+#
+# 3. Create an ECR repository for your Lambda container images:
+#    - Navigate to Amazon ECR in the AWS Console
+#    - Create a new repository with your desired name
+#    - Configure the repository policy to allow Lambda service access (see README.md)
+#
+# 4. Create a Dockerfile in your repository root with your Lambda function code
+#    - Use an AWS Lambda base image (e.g., public.ecr.aws/lambda/python:3.11)
+#    - Copy your function code and dependencies
+#    - Set the CMD to your handler function
+#
+# 5. Replace the value of the required parameters:
+#    - AWS_REGION
+#    - AWS_ROLE_TO_ASSUME
+#    - ECR_REPOSITORY
+#    - LAMBDA_FUNCTION_NAME
+#    - LAMBDA_EXECUTION_ROLE
+#
+# 6. Add any additional parameters under the environment variable section and Deploy Lambda Function step.
+
+
+name: Deploy Container to AWS Lambda
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  AWS_REGION: MY_AWS_REGION                         # set this to your AWS region
+  AWS_ROLE_TO_ASSUME: MY_ROLE_TO_ASSUME             # set this to your IAM role ARN
+  ECR_REPOSITORY: MY_ECR_REPOSITORY                 # set this to your ECR repository name
+  LAMBDA_FUNCTION_NAME: MY_FUNCTION_NAME            # set this to your Lambda function name
+  LAMBDA_EXECUTION_ROLE: MY_LAMBDA_EXECUTION_ROLE   # set this to your function's IAM execution role
+  # Include additional parameters as needed (Format as LAMBDA_PARAMETER)
+
+permissions:
+  id-token: write   # This is required for OIDC authentication
+  contents: read    # This is required to checkout the repository
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+        aws-region: ${{ env.AWS_REGION }}
+        # The role-to-assume should be the ARN of the IAM role you created for GitHub Actions OIDC
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      # Authenticates with ECR and returns the registry URL for building images
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build Docker image from Dockerfile in repository root
+        docker build -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:$IMAGE_TAG .
+        # Push the built image to ECR repository
+        docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:$IMAGE_TAG
+        # Output the full image URI for the next step
+        echo "image=$ECR_REGISTRY/${{ env.ECR_REPOSITORY }}:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Deploy Lambda Function with Container Image
+      uses: aws-actions/aws-lambda-deploy@v1.1.0
+      with:
+        function-name: ${{ env.LAMBDA_FUNCTION_NAME }}
+        package-type: Image  # Required: Indicates container deployment (not zip)
+        image-uri: ${{ steps.build-image.outputs.image }}  # ECR image URI from previous step
+        role: ${{ env.LAMBDA_EXECUTION_ROLE }}  # IAM execution role for Lambda
+        # Add any additional inputs your action supports
+        # Note: handler, runtime, and layers should not be provided for container images

--- a/examples/deploy-lambda-example.yml
+++ b/examples/deploy-lambda-example.yml
@@ -72,7 +72,7 @@ jobs:
         # The role-to-assume should be the ARN of the IAM role you created for GitHub Actions OIDC
 
     - name: Deploy Lambda Function
-      uses: aws-actions/aws-lambda-deploy@v1
+      uses: aws-actions/aws-lambda-deploy@v1.1.0
       with:
         function-name: ${{ env.LAMBDA_FUNCTION_NAME }}
         code-artifacts-dir: ${{ env.LAMBDA_CODE_ARTIFACTS_DIR }}

--- a/validations.js
+++ b/validations.js
@@ -26,11 +26,11 @@ function validateNumericInputs() {
     return { valid: false };
   }
 
-  return { 
-    valid: true, 
-    ephemeralStorage, 
-    parsedMemorySize, 
-    timeout 
+  return {
+    valid: true,
+    ephemeralStorage,
+    parsedMemorySize,
+    timeout
   };
 }
 
@@ -41,24 +41,61 @@ function validateRequiredInputs() {
     return { valid: false };
   }
 
-  const codeArtifactsDir = core.getInput('code-artifacts-dir');
-  if (!codeArtifactsDir) {
-    core.setFailed('Code-artifacts-dir must be provided');
+  // Get package type (defaults to 'Zip')
+  let packageType = core.getInput('package-type', { required: false }) || 'Zip';
+
+  // Validate package type value
+  if (!['Zip', 'Image'].includes(packageType)) {
+    core.setFailed(`Package type must be either 'Zip' or 'Image', got: ${packageType}`);
     return { valid: false };
   }
 
-  let handler = core.getInput('handler', { required: true });
-  handler = handler || 'index.handler'; 
-  
-  let runtime = core.getInput('runtime', { required: true });
-  runtime = runtime || 'node20js.x'; 
+  let codeArtifactsDir, handler, runtime, imageUri;
 
-  return { 
-    valid: true, 
-    functionName, 
+  if (packageType === 'Zip') {
+    // For Zip packages, require code-artifacts-dir, handler, and runtime
+    codeArtifactsDir = core.getInput('code-artifacts-dir');
+    if (!codeArtifactsDir) {
+      core.setFailed('code-artifacts-dir must be provided when package-type is "Zip"');
+      return { valid: false };
+    }
+
+    handler = core.getInput('handler', { required: false }) || 'index.handler';
+    runtime = core.getInput('runtime', { required: false }) || 'nodejs20.x';
+    
+    // Warn if Image-only parameters are provided with Zip package type
+    imageUri = core.getInput('image-uri', { required: false });
+    if (imageUri) {
+      core.warning('image-uri parameter is ignored when package-type is "Zip"');
+    }
+
+  } else if (packageType === 'Image') {
+    // For Image packages, require image-uri
+    imageUri = core.getInput('image-uri', { required: false });
+    if (!imageUri) {
+      core.setFailed('image-uri must be provided when package-type is "Image"');
+      return { valid: false };
+    }
+
+    // Handler and runtime are optional for container images
+    handler = core.getInput('handler', { required: false });
+    runtime = core.getInput('runtime', { required: false });
+
+    // Warn if Zip-only parameters are provided with Image package type
+    codeArtifactsDir = core.getInput('code-artifacts-dir', { required: false });
+    if (codeArtifactsDir) {
+      core.warning('code-artifacts-dir parameter is ignored when package-type is "Image"');
+    }
+  }
+
+  return {
+    valid: true,
+    functionName,
+    packageType,
     codeArtifactsDir,
     handler,
-    runtime
+    runtime,
+    imageUri
   };
 }
 
@@ -67,19 +104,19 @@ function validateArnInputs() {
   const codeSigningConfigArn = core.getInput('code-signing-config-arn', { required: false });
   const kmsKeyArn = core.getInput('kms-key-arn', { required: false });
   const sourceKmsKeyArn = core.getInput('source-kms-key-arn', { required: false });
-  
+
   if (role && !validateRoleArn(role)) {
     return { valid: false };
   }
-  
+
   if (codeSigningConfigArn && !validateCodeSigningConfigArn(codeSigningConfigArn)) {
     return { valid: false };
   }
-  
+
   if (kmsKeyArn && !validateKmsKeyArn(kmsKeyArn)) {
     return { valid: false };
   }
-  
+
   if (sourceKmsKeyArn && !validateKmsKeyArn(sourceKmsKeyArn)) {
     return { valid: false };
   }
@@ -104,7 +141,7 @@ function validateJsonInputs() {
   const snapStart = core.getInput('snap-start', { required: false });
   const loggingConfig = core.getInput('logging-config', { required: false });
   const tags = core.getInput('tags', { required: false });
-  
+
   let parsedEnvironment, parsedVpcConfig, parsedDeadLetterConfig, parsedTracingConfig,
     parsedLayers, parsedFileSystemConfigs, parsedImageConfig, parsedSnapStart,
     parsedLoggingConfig, parsedTags;
@@ -113,7 +150,7 @@ function validateJsonInputs() {
     if (environment) {
       parsedEnvironment = parseJsonInput(environment, 'environment');
     }
-    
+
     if (vpcConfig) {
       parsedVpcConfig = parseJsonInput(vpcConfig, 'vpc-config');
       if (!parsedVpcConfig.SubnetIds || !Array.isArray(parsedVpcConfig.SubnetIds)) {
@@ -123,28 +160,28 @@ function validateJsonInputs() {
         throw new Error("vpc-config must include 'SecurityGroupIds' as an array");
       }
     }
-    
+
     if (deadLetterConfig) {
       parsedDeadLetterConfig = parseJsonInput(deadLetterConfig, 'dead-letter-config');
       if (!parsedDeadLetterConfig.TargetArn) {
         throw new Error("dead-letter-config must include 'TargetArn'");
       }
     }
-    
+
     if (tracingConfig) {
       parsedTracingConfig = parseJsonInput(tracingConfig, 'tracing-config');
       if (!parsedTracingConfig.Mode || !['Active', 'PassThrough'].includes(parsedTracingConfig.Mode)) {
         throw new Error("tracing-config Mode must be 'Active' or 'PassThrough'");
       }
     }
-    
+
     if (layers) {
       parsedLayers = parseJsonInput(layers, 'layers');
       if (!Array.isArray(parsedLayers)) {
         throw new Error("layers must be an array of layer ARNs");
       }
     }
-    
+
     if (fileSystemConfigs) {
       parsedFileSystemConfigs = parseJsonInput(fileSystemConfigs, 'file-system-configs');
       if (!Array.isArray(parsedFileSystemConfigs)) {
@@ -156,22 +193,22 @@ function validateJsonInputs() {
         }
       }
     }
-    
+
     if (imageConfig) {
       parsedImageConfig = parseJsonInput(imageConfig, 'image-config');
     }
-    
+
     if (snapStart) {
       parsedSnapStart = parseJsonInput(snapStart, 'snap-start');
       if (!parsedSnapStart.ApplyOn || !['PublishedVersions', 'None'].includes(parsedSnapStart.ApplyOn)) {
         throw new Error("snap-start ApplyOn must be 'PublishedVersions' or 'None'");
       }
     }
-    
+
     if (loggingConfig) {
       parsedLoggingConfig = parseJsonInput(loggingConfig, 'logging-config');
     }
-    
+
     if (tags) {
       parsedTags = parseJsonInput(tags, 'tags');
       if (typeof parsedTags !== 'object' || Array.isArray(parsedTags)) {
@@ -190,7 +227,7 @@ function validateJsonInputs() {
     deadLetterConfig,
     tracingConfig,
     layers,
-    fileSystemConfigs, 
+    fileSystemConfigs,
     imageConfig,
     snapStart,
     loggingConfig,
@@ -201,7 +238,7 @@ function validateJsonInputs() {
     parsedTracingConfig,
     parsedLayers,
     parsedFileSystemConfigs,
-    parsedImageConfig, 
+    parsedImageConfig,
     parsedSnapStart,
     parsedLoggingConfig,
     parsedTags
@@ -247,7 +284,7 @@ function parseJsonInput(jsonString, inputName) {
 
 function validateRoleArn(arn) {
   const rolePattern = /^arn:aws(-[a-z0-9-]+)?:iam::[0-9]{12}:role\/[a-zA-Z0-9+=,.@_\/-]+$/;
-  
+
   if (!rolePattern.test(arn)) {
     core.setFailed(`Invalid IAM role ARN format: ${arn}`);
     return false;
@@ -267,7 +304,7 @@ function validateCodeSigningConfigArn(arn) {
 
 function validateKmsKeyArn(arn) {
   const kmsPattern = /^arn:aws(-[a-z0-9-]+)?:kms:[a-z0-9-]+:[0-9]{12}:key\/[a-zA-Z0-9-]+$/;
-  
+
   if (!kmsPattern.test(arn)) {
     core.setFailed(`Invalid KMS key ARN format: ${arn}`);
     return false;
@@ -289,29 +326,52 @@ function validateAndResolvePath(userPath, basePath) {
   return resolvedPath;
 }
 
+function checkInputConflicts(packageType, additionalInputs) {
+  const { s3Bucket, s3Key, useS3Method } = additionalInputs;
+  const sourceKmsKeyArn = core.getInput('source-kms-key-arn', { required: false });
+  
+  if (packageType === 'Image') {
+    // Warn about S3-related parameters being ignored for Image package type
+    if (s3Bucket) {
+      core.warning('s3-bucket parameter is ignored when package-type is "Image"');
+    }
+    if (s3Key) {
+      core.warning('s3-key parameter is ignored when package-type is "Image"');
+    }
+    if (sourceKmsKeyArn) {
+      core.warning('source-kms-key-arn parameter is ignored when package-type is "Image"');
+    }
+  }
+}
+
 function validateAllInputs() {
   const requiredInputs = validateRequiredInputs();
   if (!requiredInputs.valid) {
     return { valid: false };
   }
-  
+
   const numericInputs = validateNumericInputs();
   if (!numericInputs.valid) {
     return { valid: false };
   }
-  
+
   const arnInputs = validateArnInputs();
   if (!arnInputs.valid) {
     return { valid: false };
   }
-  
+
   const jsonInputs = validateJsonInputs();
   if (!jsonInputs.valid) {
     return { valid: false };
   }
-  
+
   const additionalInputs = getAdditionalInputs();
   
+  // Check for input conflicts based on package type
+  if (requiredInputs.packageType) {
+    checkInputConflicts(requiredInputs.packageType, additionalInputs);
+  }
+
   return {
     valid: true,
     ...requiredInputs,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-actions/aws-lambda-deploy/issues/23

*Description of changes:*
Enables passing in `image-uri` to Lambda so it's possible to deploy functions with ECR container images.

Also includes examples and updates docs for how to create a workflow that builds a container, uploads it to ECR, and passes that URI to your Lambda function. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.