### PR TITLE
fix: remove extra checkout step

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,12 +10,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Init a git repo
-        uses: actions/checkout@v5
       - name: Checkout PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.pull_request.number }}
+        uses: actions/checkout@v5
       - name: Package
         run: |
           npm ci


### PR DESCRIPTION
*Description of changes:*
`actions/checkout` will automatically checkout the correct PR branch according to https://github.com/actions/checkout?tab=readme-ov-file#usage. Removing the extra steps allows us to get rid of an inline script that is a potential attack vector.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.