### PR TITLE
fix: Update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,5 +105,5 @@ outputs:
     description: 'The function version if a new version was published.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
*Resolves:* #66

Node.js 20 actions are deprecated and will be forced to run on Node.js 24 starting June 2, 2026.

*Changes:*
- Update action runtime declaration from `node20` to `node24`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.