### PR TITLE
docs: correct publish input default to false in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Below are two commonly used Build examples for Node.js and Python:
 | `runtime` | Function runtime identifier (required when package-type is `Zip`) | No | `nodejs20.x` |
 | `s3-bucket` | S3 bucket name for Lambda deployment package. Uses S3 deployment method if provided | No | |
 | `s3-key` | S3 key (path) for the Lambda deployment package | No | Auto-generated |
-| `publish` | Publish a new version of the function after updating | No | `true` |
+| `publish` | Publish a new version of the function after updating | No | `false` |
 | `dry-run` | Validate parameters and permissions without modifications | No | `false` |
 | `revision-id` | Update only if the revision ID matches the specified ID | No | |
 | `architectures` | Function instruction set architecture | No | `x86_64` |


### PR DESCRIPTION

The README's input table claims `publish` defaults to `true`, but the
actual default in both this action and the underlying AWS Lambda API
is `false`:

  - action.yml has no `default:` for the `publish` input, so an unset
    input is undefined.
  - validations.js initializes `publish` to false and falls back to
    false on any parse error.
  - index.js only adds `Publish` to CreateFunction / UpdateFunctionCode
    when `publish !== undefined`, so omitting the input means AWS uses
    its own default.
  - The AWS Lambda CreateFunction API treats `Publish` as an optional
    Boolean that is not required; the documented behavior is that you
    must set it to true to publish, and omitting it does not publish.
    https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html

Issue #58 reports this discrepancy and offers two options: change the
docs, or change the default behavior. Changing the default to true
(as attempted in PR #63) would be a breaking change for every
existing user — every deploy would suddenly publish a new version,
and the action's behavior would diverge from the AWS API default.
The maintainer pushback on #63 points to this as well.

This change takes the docs-only path: align the documentation with
the actual (and AWS-standard) behavior. No code change.

Refs #58, #63.
