### PR TITLE
feat: warn about ignored inputs and remove misleading defaults

### DIFF
--- a/__tests__/validations.test.js
+++ b/__tests__/validations.test.js
@@ -1582,12 +1582,68 @@ describe('Validations Tests', () => {
         };
         return inputs[name] || '';
       });
-      
+
       const result = originalValidations.validateAllInputs();
       expect(result.valid).toBe(true);
       // Check that warning was not called for S3 parameters
       expect(core.warning).not.toHaveBeenCalledWith(expect.stringContaining('s3-bucket'));
       expect(core.warning).not.toHaveBeenCalledWith(expect.stringContaining('s3-key'));
+    });
+
+    test('should warn when handler/runtime/layers are provided with Image package type', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'package-type': 'Image',
+          'image-uri': '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest',
+          'handler': 'index.handler',
+          'runtime': 'nodejs20.x',
+          'layers': '["arn:aws:lambda:us-east-1:123456789012:layer:my-layer:1"]',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(true);
+      expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('handler parameter is ignored when package-type is "Image"'));
+      expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('runtime parameter is ignored when package-type is "Image"'));
+      expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('layers parameter is ignored when package-type is "Image"'));
+    });
+
+    test('should not warn about handler/runtime/layers when not provided with Image package type', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'package-type': 'Image',
+          'image-uri': '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(true);
+      expect(core.warning).not.toHaveBeenCalledWith(expect.stringContaining('handler parameter is ignored'));
+      expect(core.warning).not.toHaveBeenCalledWith(expect.stringContaining('runtime parameter is ignored'));
+      expect(core.warning).not.toHaveBeenCalledWith(expect.stringContaining('layers parameter is ignored'));
+    });
+
+    test('should warn when image-config is provided with Zip package type', () => {
+      core.getInput.mockImplementation((name) => {
+        const inputs = {
+          'function-name': 'test-function',
+          'package-type': 'Zip',
+          'code-artifacts-dir': './artifacts',
+          'image-config': '{"Command":["app.handler"]}',
+          'region': 'us-east-1'
+        };
+        return inputs[name] || '';
+      });
+
+      const result = originalValidations.validateAllInputs();
+      expect(result.valid).toBe(true);
+      expect(core.warning).toHaveBeenCalledWith('image-config parameter is ignored when package-type is "Zip"');
     });
   });
 

--- a/action.yml
+++ b/action.yml
@@ -15,13 +15,11 @@ inputs:
     description: 'The path to a directory of code artifacts to zip and deploy to Lambda. Required when package-type is "Zip".'
     required: false
   handler:
-    description: 'The name of the method within your code that Lambda calls to run your function. Required when package-type is "Zip".'
+    description: 'The name of the method within your code that Lambda calls to run your function. Required when package-type is "Zip". Defaults to "index.handler" when omitted.'
     required: false
-    default: 'index.handler'
   runtime:
-    description: 'The identifier of the runtime. Required when package-type is "Zip".'
+    description: 'The identifier of the runtime. Required when package-type is "Zip". Defaults to "nodejs20.x" when omitted.'
     required: false
-    default: 'nodejs20.x'
   s3-bucket:
     description: 'S3 bucket name to use for Lambda deployment package. If provided, S3 deployment method will be used instead of direct upload.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -98270,7 +98270,7 @@ function validateAndResolvePath(userPath, basePath) {
 function checkInputConflicts(packageType, additionalInputs) {
   const { s3Bucket, s3Key } = additionalInputs;
   const sourceKmsKeyArn = core.getInput('source-kms-key-arn', { required: false });
-  
+
   if (packageType === 'Image') {
     // Warn about S3-related parameters being ignored for Image package type
     if (s3Bucket) {
@@ -98281,6 +98281,25 @@ function checkInputConflicts(packageType, additionalInputs) {
     }
     if (sourceKmsKeyArn) {
       core.warning('source-kms-key-arn parameter is ignored when package-type is "Image"');
+    }
+    // Warn about Zip-only parameters being ignored for Image package type.
+    // For container image functions, the runtime, handler, and layers are
+    // baked into the image itself, so any value supplied here would be
+    // silently dropped without these warnings.
+    if (core.getInput('handler', { required: false })) {
+      core.warning('handler parameter is ignored when package-type is "Image"; the handler is determined by the container image');
+    }
+    if (core.getInput('runtime', { required: false })) {
+      core.warning('runtime parameter is ignored when package-type is "Image"; the runtime is determined by the container image');
+    }
+    if (core.getInput('layers', { required: false })) {
+      core.warning('layers parameter is ignored when package-type is "Image"; layers are not supported for container image functions');
+    }
+  } else if (packageType === 'Zip') {
+    // Warn about Image-only parameters being ignored for Zip package type.
+    // image-uri is already warned about in validateRequiredInputs.
+    if (core.getInput('image-config', { required: false })) {
+      core.warning('image-config parameter is ignored when package-type is "Zip"');
     }
   }
 }

--- a/validations.js
+++ b/validations.js
@@ -350,7 +350,7 @@ function validateAndResolvePath(userPath, basePath) {
 function checkInputConflicts(packageType, additionalInputs) {
   const { s3Bucket, s3Key } = additionalInputs;
   const sourceKmsKeyArn = core.getInput('source-kms-key-arn', { required: false });
-  
+
   if (packageType === 'Image') {
     // Warn about S3-related parameters being ignored for Image package type
     if (s3Bucket) {
@@ -361,6 +361,25 @@ function checkInputConflicts(packageType, additionalInputs) {
     }
     if (sourceKmsKeyArn) {
       core.warning('source-kms-key-arn parameter is ignored when package-type is "Image"');
+    }
+    // Warn about Zip-only parameters being ignored for Image package type.
+    // For container image functions, the runtime, handler, and layers are
+    // baked into the image itself, so any value supplied here would be
+    // silently dropped without these warnings.
+    if (core.getInput('handler', { required: false })) {
+      core.warning('handler parameter is ignored when package-type is "Image"; the handler is determined by the container image');
+    }
+    if (core.getInput('runtime', { required: false })) {
+      core.warning('runtime parameter is ignored when package-type is "Image"; the runtime is determined by the container image');
+    }
+    if (core.getInput('layers', { required: false })) {
+      core.warning('layers parameter is ignored when package-type is "Image"; layers are not supported for container image functions');
+    }
+  } else if (packageType === 'Zip') {
+    // Warn about Image-only parameters being ignored for Zip package type.
+    // image-uri is already warned about in validateRequiredInputs.
+    if (core.getInput('image-config', { required: false })) {
+      core.warning('image-config parameter is ignored when package-type is "Zip"');
     }
   }
 }


### PR DESCRIPTION

When deploying with `package-type: Image`, several Zip-only inputs
(`runtime`, `handler`, `layers`) are silently dropped: index.js gates
each of them with `packageType === 'Zip' && ...` before sending the
CreateFunction / UpdateFunctionConfiguration request. Today the action
neither warns about the dropped values nor stops echoing the action's
own defaults into the workflow log, so the user has no signal that
their `runtime: nodejs20.x` (etc.) has no effect on the deployed
container function.

This is the same shape of footgun the action already guards against
for `s3-bucket` / `s3-key` / `source-kms-key-arn` on the Image side
and for `image-uri` / `code-artifacts-dir` on the Zip side — those
inputs already produce explicit `core.warning(...)` lines. This commit
extends the same treatment to the remaining Zip-only / Image-only
inputs.

Changes:

  - validations.js: in checkInputConflicts, emit a warning when
    `handler`, `runtime`, or `layers` is supplied with
    package-type: Image, and when `image-config` is supplied with
    package-type: Zip. Each warning explains why the input is being
    ignored.

  - action.yml: remove `default: 'index.handler'` from `handler` and
    `default: 'nodejs20.x'` from `runtime`. These defaults are
    injected into every action invocation by GitHub Actions and end
    up echoed in the `with:` block of the run log, even when the
    user did not write them — which is the exact source of confusion
    reported by users seeing `runtime: nodejs20.x` in their Image
    deploy logs (where it has no effect). The Zip fallback behavior
    is preserved by validations.js, which already falls back to
    `'index.handler'` and `'nodejs20.x'` when the input is empty —
    so existing Zip users that omit either input keep getting the
    same Lambda runtime/handler. The default values are now
    documented in the input descriptions instead.

Tests:

  - Three new cases under __tests__/validations.test.js
    `Input Conflict Warnings`:
      * warns about handler/runtime/layers for Image
      * does not warn when those inputs are omitted on Image
      * warns about image-config for Zip

dist/index.js is rebuilt with `npm run build` (ncc 0.36.1) since
validations.js is bundled into it.
